### PR TITLE
typo: level disable command format

### DIFF
--- a/Marlin/Creality_DWIN.cpp
+++ b/Marlin/Creality_DWIN.cpp
@@ -1385,7 +1385,7 @@ SERIAL_ECHO(Checkkey);
 				{
 					RTS_SndData(2, AutoLevelIcon);
 					AutoLevelStatus = true;
-					enqueue_and_echo_commands_P((PSTR("M420 0")));
+					enqueue_and_echo_commands_P((PSTR("M420 S0")));
 				}
 				last_zoffset = rts_probe_zoffset;
 				RTS_SndData(zprobe_zoffset*100, 0x1026); 


### PR DESCRIPTION
Fixing a typo avoiding to disable leveling
See some manual debugging output below

```
Send: M420
[...]
Recv: echo:Bed Leveling On
Recv: echo:Fade Height Off
Recv: ok P15 B3
[...]
Send: M420 0
Recv: echo:Bed Leveling On
Recv: echo:Fade Height Off
Recv: ok P15 B3
[...]
Send: M420 S0
Recv: echo:Bed Leveling Off
Recv: echo:Fade Height Off
Recv: ok P15 B3
```