### PR TITLE
Add support for the Trex 3 that was upgraded from the 2+ from the kit.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -24,6 +24,9 @@
  // If you have a trex 3, stock is this option plus 2208 on all axis. None in spreadcycle.
 #define TREX3
 
+// If you have a trex 3 that was upgraded from a 2+ with the kit, modifies home position and offsets.
+#define TREX3_UPGRADED_FROM_2_PLUS
+
 //#define X_2208
 //#define X_Spreadcycle
 //#define X_S109
@@ -49,6 +52,11 @@
 
 
 //////////////////////////////////DO not edit below here unless you know what youre doing!  //////////////////////////////////
+
+// The TREX2+ upgraded to the 3 enables most of the same options, simplify here
+#if ENABLED(TREX3_UPGRADED_FROM_2_PLUS)
+  #define TREX3
+#endif
 
 #if ENABLED(TREX3)
   #if DISABLED(X_S109)
@@ -184,7 +192,9 @@
 
 // Optional custom name for your RepStrap or other custom machine
 // Displayed in the LCD "Ready" message
-#if ENABLED(TREX3)
+#if ENABLED(TREX3_UPGRADED_FROM_2_PLUS)
+#define CUSTOM_MACHINE_TIME "T-REX 3(u)"
+#elif ENABLED(TREX3)
   #define CUSTOM_MACHINE_NAME "T-REX 3"
 #else
   #define CUSTOM_MACHINE_NAME "T-REX 2+"
@@ -1133,11 +1143,25 @@
 #define Y_BED_SIZE 400
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
-#define X_MIN_POS -47
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 460
-#define Y_MAX_POS Y_BED_SIZE
+#if ENABLED(TREX3_UPGRADED_FROM_2_PLUS)
+    #define X_MIN_POS -42
+    #define Y_MIN_POS 0
+    #define Z_MIN_POS 0
+    #define X_MAX_POS 450
+    #define Y_MAX_POS Y_BED_SIZE
+#elif ENABLED(TREX3)
+    #define X_MIN_POS -47
+    #define Y_MIN_POS 0
+    #define Z_MIN_POS 0
+    #define X_MAX_POS 460
+    #define Y_MAX_POS Y_BED_SIZE
+#else
+    #define X_MIN_POS -42
+    #define Y_MIN_POS 0
+    #define Z_MIN_POS 0
+    #define X_MAX_POS 450
+    #define Y_MAX_POS Y_BED_SIZE
+#endif
 #if(ENABLED(tallVersion))
   #define Z_MAX_POS 700
 #else

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -435,6 +435,10 @@
 #if ENABLED(DUAL_X_CARRIAGE)
   #define X1_MIN_POS X_MIN_POS   // Set to X_MIN_POS
   #define X1_MAX_POS X_BED_SIZE  // Set a maximum so the first X-carriage can't hit the parked second X-carriage
+  #if ENABLED(TREX3_UPGRADED_FROM_2_PLUS)
+  #else
+  #define X2_MIN_POS    0        // Set a minimum to ensure the  second X-carriage can't hit the parked first X-carriage
+  #endif
   #define X2_MIN_POS    80       // Set a minimum to ensure the  second X-carriage can't hit the parked first X-carriage
   #if ENABLED(TREX3)
     #define X2_MAX_POS 446       // Set this to the distance between toolheads when both heads are homed


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Add support for a Formbot 3 that was upgraded from a 2+ via the official kit.  The kit included the same electronics, board, etc from the full 3 model, but has some slight differences in homing positions and offsets from the 2+ base hardware.

I am working on the configuration and have run basics tests, but am not confident the changes are complete yet.  Further review and testing is required, but I wanted to get some feedback.

### Benefits

Adds easy configuration for the kit, so users can just set a single option and properly configure the settings.

### Related Issues

