### PR TITLE
Fixed include paths

### DIFF
--- a/Marlin/src/lcd/extensible_ui/lib/Creality_DWIN.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/Creality_DWIN.cpp
@@ -1,7 +1,6 @@
 #include "Creality_DWIN.h"
 #include <HardwareSerial.h>
-#include <arduino.h>
-#include <wstring.h>
+#include <WString.h>
 #include <stdio.h>
 #include "../ui_api.h"
 

--- a/Marlin/src/lcd/extensible_ui/lib/Creality_DWIN.h
+++ b/Marlin/src/lcd/extensible_ui/lib/Creality_DWIN.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "string.h"
-#include <arduino.h>
+#include <Arduino.h>
 #include "../ui_api.h"
 
 namespace ExtUI {


### PR DESCRIPTION
Currently building this on Linux (and I think Mac too) fails, since Creality_DWIN.{h,cpp} are including _Arduino.h_ and _WString.h_ lowercase.

The official Arduino distribution fetched from [Arduino](https://www.arduino.cc/) ships them upper case as written above. This Pull Requests just changes those two includes and removes a redundant import of Arduino.h within Creality_DWIN.cpp.