### PR TITLE
Creality dwin2.0 bleeding

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -37,7 +37,7 @@
 //#define OrigLCD // Upgraded mainboard with single cable Ender LCD
 //#define GraphicLCD //Full graphics LCD for Ender 4, CR-X or CR10SPro
 //#define ForceCRXDisplay
-#define Force10SProDisplay
+//#define Force10SProDisplay
 
 //#define AddonFilSensor //Adds a filamnt runout sensor to the CR20 or Ender 4
 //#define lerdgeFilSensor //Using lerdge filament sensor, which is opposite polarity to stock
@@ -46,9 +46,12 @@
 //#define MachineCR10Orig // Forces Melzi board
 //#define Melzi_To_SBoardUpgrade // Upgrade Melzi board to 10S board
 //#define SKR13 // 32 bit board - assumes 2208 drivers
-//#define SKR13_2209
-//#define SKR13_UART // Configure SKR board with drivers in UART mode
+#define SKRPRO11  // 32 bit board - assumes 2208 drivers
+#define SKR_2209
+#define SKR_UART // Configure SKR board with drivers in UART mode
 //#define SKR13_ReverseSteppers // Some users reported directions backwards than others on SKR with various drivers.
+
+#define I2C_EEPROM  // use I2C EEPROM on SRK PRO v1.1 e.g AT24C256
 
 /*
    Hotend Type
@@ -331,6 +334,13 @@
   #define SolidBedMounts
 #endif
 
+#if ENABLED(SKRPRO11)
+  #define FIL_RUNOUT_PIN   PE15
+  #if DISABLED(I2C_EEPROM)
+    #define FLASH_EEPROM_EMULATION
+  #endif
+#endif
+
 //Show the Marlin bootscreen on startup. ** ENABLE FOR PRODUCTION **
 
 #if NONE(MachineCR10Orig, MachineEnder4, MachineCR10SPro, MachineCRX, MachineCR10Max, MachineEnder5Plus) || ENABLED(GraphicLCD)
@@ -349,7 +359,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#if ENABLED(SKR13)
+#if ANY(SKR13, SKRPRO11)
   #define SERIAL_PORT -1
 #else
   #define SERIAL_PORT 0
@@ -364,6 +374,8 @@
  */
 #if ENABLED(SKR13)
   #define SERIAL_PORT_2 0
+#elif ENABLED(SKRPRO11)
+  //#define SERIAL_PORT_2 1
 #endif
 /**
  * This setting determines the communication speed of the printer.
@@ -383,6 +395,8 @@
 #ifndef MOTHERBOARD
   #if ENABLED(SKR13)
     #define MOTHERBOARD BOARD_BIGTREE_SKR_V1_3
+  #elif ENABLED(SKRPRO11)
+    #define MOTHERBOARD BOARD_BIGTREE_SKR_PRO_V1_1
   #elif (ENABLED(MachineCR10Orig) && DISABLED(Melzi_To_SBoardUpgrade))
     #define MOTHERBOARD BOARD_MELZI_CREALITY
   #else
@@ -1022,8 +1036,8 @@
  * :['A4988', 'A5984', 'DRV8825', 'LV8729', 'L6470', 'TB6560', 'TB6600', 'TMC2100', 'TMC2130', 'TMC2130_STANDALONE', 'TMC2160', 'TMC2160_STANDALONE', 'TMC2208', 'TMC2208_STANDALONE', 'TMC2209', 'TMC2209_STANDALONE', 'TMC26X', 'TMC26X_STANDALONE', 'TMC2660', 'TMC2660_STANDALONE', 'TMC5130', 'TMC5130_STANDALONE', 'TMC5160', 'TMC5160_STANDALONE']
  */
 
-#if ANY(SKR13, MachineCR10SV2) && DISABLED(SKR13_UART)
-  #if ENABLED(SKR13_2209)
+#if ANY(SKR13, SKRPRO11, MachineCR10SV2) && DISABLED(SKR_UART)
+  #if ENABLED(SKR_2209)
     #define X_DRIVER_TYPE  TMC2209_STANDALONE
     #define Y_DRIVER_TYPE  TMC2209_STANDALONE
     #define Z_DRIVER_TYPE  TMC2209_STANDALONE
@@ -1036,8 +1050,8 @@
     #define E0_DRIVER_TYPE TMC2208_STANDALONE
     #define E1_DRIVER_TYPE TMC2208_STANDALONE
   #endif
-#elif ENABLED(SKR13, SKR13_UART)
-  #if ENABLED(SKR13_2209)
+#elif ANY(SKR13, SKRPRO11) && ENABLED(SKR_UART)
+  #if ENABLED(SKR_2209)
     #define X_DRIVER_TYPE  TMC2209
     #define Y_DRIVER_TYPE  TMC2209
     #define Z_DRIVER_TYPE  TMC2209

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1930,7 +1930,7 @@
   #endif
 
   #if AXIS_IS_TMC(Z)
-    #define Z_CURRENT     850
+    #define Z_CURRENT     720
     #define Z_MICROSTEPS   16
     #define Z_RSENSE     0.11
     #define Z_CHAIN_POS    -1

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1401,7 +1401,7 @@
  * See http://marlinfw.org/docs/features/lin_advance.html for full instructions.
  * Mention @Sebastianv650 on GitHub to alert the author of any issues.
  */
-#if NONE(MachineCR10Orig, LowMemoryBoard, MachineCR10SPro, MachineCR10Max, SKR13, MachineCR10SV2) || ENABLED(OrigLA) || ENABLED(SKR13, SKR13_UART)
+#if NONE(MachineCR10Orig, LowMemoryBoard, MachineCR10SPro, MachineCR10Max, SKR13, MachineCR10SV2) || ENABLED(OrigLA) || ENABLED(SKR13, SKR_UART) || ENABLED(SKRPRO11, SKR_UART)
   #define LIN_ADVANCE
 #endif
 #if ENABLED(LIN_ADVANCE)
@@ -1625,7 +1625,9 @@
 // enter the serial receive buffer, so they cannot be blocked.
 // Currently handles M108, M112, M410
 // Does not work on boards using AT90USB (USBCON) processors!
-#define EMERGENCY_PARSER
+#if DISABLED(SKRPRO11)
+  #define EMERGENCY_PARSER
+#endif
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
@@ -1900,7 +1902,7 @@
   #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
 
   #if AXIS_IS_TMC(X)
-    #define X_CURRENT     800  // (mA) RMS current. Multiply by 1.414 for peak current.
+    #define X_CURRENT     730  // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_MICROSTEPS   16  // 0..256
     #define X_RSENSE     0.11
     #define X_CHAIN_POS    -1  // <=0 : Not chained. 1 : MCU MOSI connected. 2 : Next in chain, ...
@@ -1914,7 +1916,7 @@
   #endif
 
   #if AXIS_IS_TMC(Y)
-    #define Y_CURRENT     800
+    #define Y_CURRENT     740
     #define Y_MICROSTEPS   16
     #define Y_RSENSE     0.11
     #define Y_CHAIN_POS    -1
@@ -1928,7 +1930,7 @@
   #endif
 
   #if AXIS_IS_TMC(Z)
-    #define Z_CURRENT     800
+    #define Z_CURRENT     850
     #define Z_MICROSTEPS   16
     #define Z_RSENSE     0.11
     #define Z_CHAIN_POS    -1
@@ -1949,7 +1951,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT    800
+    #define E0_CURRENT    730
     #define E0_MICROSTEPS  16
     #define E0_RSENSE    0.11
     #define E0_CHAIN_POS   -1
@@ -2088,7 +2090,9 @@
    * M912 - Clear stepper driver overtemperature pre-warn condition flag.
    * M122 - Report driver parameters (Requires TMC_DEBUG)
    */
-  //#define MONITOR_DRIVER_STATUS
+  #if ENABLED(SKR_UART)
+    #define MONITOR_DRIVER_STATUS
+  #endif
 
   #if ENABLED(MONITOR_DRIVER_STATUS)
     #define CURRENT_STEP_DOWN     50  // [mA]
@@ -2105,14 +2109,14 @@
    */
   #define HYBRID_THRESHOLD
 
-  #define X_HYBRID_THRESHOLD     100  // [mm/s]
+  #define X_HYBRID_THRESHOLD     150  // [mm/s]
   #define X2_HYBRID_THRESHOLD    100
-  #define Y_HYBRID_THRESHOLD     100
+  #define Y_HYBRID_THRESHOLD     150
   #define Y2_HYBRID_THRESHOLD    100
-  #define Z_HYBRID_THRESHOLD       3
-  #define Z2_HYBRID_THRESHOLD      3
+  #define Z_HYBRID_THRESHOLD      10
+  #define Z2_HYBRID_THRESHOLD     10
   #define Z3_HYBRID_THRESHOLD      3
-  #define E0_HYBRID_THRESHOLD     30
+  #define E0_HYBRID_THRESHOLD     50
   #define E1_HYBRID_THRESHOLD     30
   #define E2_HYBRID_THRESHOLD     30
   #define E3_HYBRID_THRESHOLD     30
@@ -2174,7 +2178,9 @@
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */
-  //#define TMC_DEBUG
+    #if ENABLED(SKR_UART)
+      #define TMC_DEBUG
+    #endif
 
   /**
    * You can set your own advanced settings by filling in predefined functions.

--- a/Marlin/src/lcd/extensible_ui/lib/Creality_DWIN.h
+++ b/Marlin/src/lcd/extensible_ui/lib/Creality_DWIN.h
@@ -85,6 +85,8 @@ namespace ExtUI {
 
 #if ENABLED(SKR13)
   #define DWIN_SERIAL MSerial
+#elif ENABLED(SKRPRO11)
+  #define DWIN_SERIAL Serial1
 #else
   #define DWIN_SERIAL Serial2
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -485,7 +485,8 @@ build_flags   = ${common.build_flags}
 lib_deps      =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
-  TMCStepper@>=0.5.0,<1.0.0
+  #TMCStepper@>=0.5.0,<1.0.0
+  TMCStepper=https://github.com/bigtreetech/TMCStepper
   Adafruit NeoPixel
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip


### PR DESCRIPTION
### Requirements

SKR Pro V1.1 board
optional, an I2C EEPROM module, e.g AT24C256



### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

added support for SKR Pro V1.1

rename SKR13_2209 and SKR13_UART to SKR_2209 and SKR_UART to imply that they can be used for both SKR V1.3 and SKR Pro V1.1 boards


tested with the I2C EEPROM module (AT24C256), and UBL enabled



### Benefits

<!-- What does this fix or improve? -->
support for SKR Pro V1.1

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

p.s the build in SD card on the SKR PRO v1.1 board does not work for printing. 
test print was done via octoprint.


----------------


![CR-10S PRO - SKR Pro V1 1 - Breakout board - 01](https://user-images.githubusercontent.com/20982257/68934592-e765f700-07d1-11ea-960f-7ff3d53f1245.jpg)
there were a few issues with this mount, will post this once it is finalized.

![CR-10S PRO - SKR Pro V1 1 - Breakout board - 02](https://user-images.githubusercontent.com/20982257/68934591-e6cd6080-07d1-11ea-9034-860b60d6db36.jpg)
E stepper motor cable was the wrong way in this pic

![CR-10S PRO - SKR Pro V1 1 - Breakout board - 03](https://user-images.githubusercontent.com/20982257/68934594-e765f700-07d1-11ea-8ec1-d9edea14fac6.jpg)
still testing, hence why the cable mess. will clean up and crimp some proper cables soon.
