### PR TITLE
Attempt to rework decreasing accuracy and direction reversal

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -192,6 +192,7 @@ struct XYval {
   FI void set(const T px)                               { x = px; }
   FI void set(const T px, const T py)                   { x = px; y = py; }
   FI void reset()                                       { x = y = 0; }
+  FI void swap(const XYval<T>& val)                     { SWAP(x, val.x); SWAP(y, val.y); }
   FI T magnitude()                                const { return (T)sqrtf(x*x + y*y); }
   FI operator T* ()                                     { return pos; }
   FI operator bool()                                    { return x || y; }


### PR DESCRIPTION
This is all an experiment, but I just wanted to show you what I was playing with. It works better for me as far as detecting decreasing accuracy goes, but I am of course not testing direction reversal. I haven't done a whole lot of testing, as I'm only working on this maybe 20-30 minutes at a time.

The changes in this look big, but they basically fall into two categories:

1. Detect decreasing accuracy by summing all the calculated moves. Accuracy has decreased if this increases after a move.

2. Reverse direction only for dual-Z. Rather than reversing the move direction, move the opposite motor. This ensures the move is still away from the nozzle. Swap probe points so that it will be correct in following iterations.
  - Only allow reversing directions once, to avoid the possibility of oscillating between two overshoots.


I probably lost the special 2nd-iteration correction that the old code did. I intended to try to restore that, but didn't do it before I left last night.