### PR TITLE
Fix TOUCH_MI_PROBE issues

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -77,7 +77,8 @@
 */
 //#define ABL_EZABL // TH3D EZABL or Any NO Sensor
 //#define ABL_NCSW //Creality ABL or Any NC Sensor
-#define ABL_BLTOUCH
+//#define ABL_BLTOUCH
+#define ABL_TOUCH_MI // Uncomment ABL_TOUCH_MI to use Touch-MI sensor by hotends.fr
 
 //#define CREALITY_ABL_MOUNT //Using creality ABL mount
 //#define E3D_DUALFAN_MOUNT // Using HD Modular mount as above with 2 5015 blowers and sensor on the right
@@ -276,8 +277,12 @@
 
 #if(ENABLED(MachineCR10SPro))
   #define MachineCR10Std
-  #if DISABLED(ABL_BLTOUCH, ABL_EZABL)
+  #if DISABLED(ABL_BLTOUCH, ABL_EZABL, ABL_TOUCH_MI)
     #define ABL_NCSW
+  #endif
+  #if ENABLED(ABL_TOUCH_MI)
+    #define TOUCH_MI_PROBE
+    #define Z_MIN_PIN 12
   #endif
   #if DISABLED(ABL_UBL)
     #define ABL_BI
@@ -348,7 +353,7 @@
   #define HotendStock
 #endif
 
-#if ANY(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH) && NONE(ABL_UBL, ABL_BI)
+#if ANY(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH, ABL_TOUCH_MI) && NONE(ABL_UBL, ABL_BI)
   #define ABL_BI
 #endif
 
@@ -1373,7 +1378,7 @@
  * Use G29 repeatedly, adjusting the Z height at each point with movement commands
  * or (with LCD_BED_LEVELING) the LCD controller.
  */
-#if DISABLED(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH)
+#if DISABLED(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH, ABL_TOUCH_MI)
   #define PROBE_MANUALLY
   #define MANUAL_PROBE_START_Z 0.2
 #endif
@@ -1554,8 +1559,9 @@
 #endif
 #define Z_CLEARANCE_BETWEEN_PROBES  5 // Z Clearance between probe points
 #define Z_CLEARANCE_MULTI_PROBE     5 // Z Clearance between multiple probes
-#define Z_AFTER_PROBING           5 // Z position after probing is done
-
+#if DISABLED(TOUCH_MI_PROBE)
+  #define Z_AFTER_PROBING           5 // Z position after probing is done
+#endif
 #define Z_PROBE_LOW_POINT          -3 // Farthest distance below the trigger-point to go before stopping
 
 // For M851 give a range for adjusting the Z probe offset
@@ -1563,7 +1569,7 @@
 #define Z_PROBE_OFFSET_RANGE_MAX 20
 
 // Enable the M48 repeatability test to test probe accuracy
-#if ANY(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW) && DISABLED(MachineCR10Orig)
+#if ANY(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW, ABL_TOUCH_MI) && DISABLED(MachineCR10Orig)
   #define Z_MIN_PROBE_REPEATABILITY_TEST
 #endif
 
@@ -1674,9 +1680,12 @@
 //#define UNKNOWN_Z_NO_RAISE // Don't raise Z (lower the bed) if Z is "unknown." For beds that fall when Z is powered off.
 #if ANY(MachineEnder5, MachineEnder5Plus)
   #define Z_HOMING_HEIGHT 0
-#else
-#define Z_HOMING_HEIGHT 4  // (in mm) Minimal z height before homing (G28) for Z clearance above the bed, clamps, ...
-                             // Be sure you have this distance over your Z_MAX_POS in case.
+#else 
+  #if ENABLED(TOUCH_MI_PROBE)  
+    #define Z_HOMING_HEIGHT 10
+  #else
+    #define Z_HOMING_HEIGHT 4  // (in mm) Minimal z height before homing (G28) for Z clearance above the bed, clamps, ...
+  #endif                           // Be sure you have this distance over your Z_MAX_POS in case.
 #endif
 
 // Direction of endstops when homing; 1=MAX, -1=MIN
@@ -1695,7 +1704,7 @@
 
 // The size of the print bed
 
-#if NONE(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW)
+#if NONE(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW, ABL_TOUCH_MI)
 
   #if ENABLED(MachineMini)
     #define X_BED_SIZE 300
@@ -1821,8 +1830,14 @@
 #endif
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
+#if ENABLED(TOUCH_MI_PROBE)
+  #define X_MIN_POS -4
+  #define Y_MIN_POS -10
+#else
+  #define X_MIN_POS 0
+  #define Y_MIN_POS 0
+#endif
+
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
@@ -1948,7 +1963,7 @@
  */
 //#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
-#if (ENABLED(ABL_EZABL)|| ENABLED(ABL_BLTOUCH) || ENABLED(ABL_NCSW))
+#if (ENABLED(ABL_EZABL)|| ENABLED(ABL_BLTOUCH) || ENABLED(ABL_NCSW)) || ENABLED(ABL_TOUCH_MI)
   #if ((ENABLED(ABL_UBL)))
     #define AUTO_BED_LEVELING_UBL
     #endif
@@ -2086,7 +2101,7 @@
  * Add a bed leveling sub-menu for ABL or MBL.
  * Include a guided procedure if manual probing is enabled.
  */
-#if NONE(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH) && (DISABLED(MachineCRX) || ENABLED(GraphicLCD))
+#if NONE(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH, ABL_TOUCH_MI) && (DISABLED(MachineCRX) || ENABLED(GraphicLCD))
 #define LCD_BED_LEVELING
 #endif
 
@@ -2133,7 +2148,7 @@
 // - Move the Z probe (or nozzle) to a defined XY point before Z Homing when homing all axes (G28).
 // - Prevent Z homing when the Z probe is outside bed area.
 //
-#if ANY(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH)
+#if ANY(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH, ABL_TOUCH_MI)
   #define Z_SAFE_HOMING
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -77,8 +77,8 @@
 */
 //#define ABL_EZABL // TH3D EZABL or Any NO Sensor
 //#define ABL_NCSW //Creality ABL or Any NC Sensor
-//#define ABL_BLTOUCH
-#define ABL_TOUCH_MI // Uncomment ABL_TOUCH_MI to use Touch-MI sensor by hotends.fr
+#define ABL_BLTOUCH
+//#define ABL_TOUCH_MI // Uncomment ABL_TOUCH_MI to use Touch-MI sensor by hotends.fr
 
 //#define CREALITY_ABL_MOUNT //Using creality ABL mount
 //#define E3D_DUALFAN_MOUNT // Using HD Modular mount as above with 2 5015 blowers and sensor on the right
@@ -282,7 +282,6 @@
   #endif
   #if ENABLED(ABL_TOUCH_MI)
     #define TOUCH_MI_PROBE
-    #define Z_MIN_PIN 12
   #endif
   #if DISABLED(ABL_UBL)
     #define ABL_BI
@@ -1680,8 +1679,8 @@
 //#define UNKNOWN_Z_NO_RAISE // Don't raise Z (lower the bed) if Z is "unknown." For beds that fall when Z is powered off.
 #if ANY(MachineEnder5, MachineEnder5Plus)
   #define Z_HOMING_HEIGHT 0
-#else 
-  #if ENABLED(TOUCH_MI_PROBE)  
+#else
+  #if ENABLED(TOUCH_MI_PROBE)
     #define Z_HOMING_HEIGHT 10
   #else
     #define Z_HOMING_HEIGHT 4  // (in mm) Minimal z height before homing (G28) for Z clearance above the bed, clamps, ...
@@ -1963,14 +1962,14 @@
  */
 //#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
-#if (ENABLED(ABL_EZABL)|| ENABLED(ABL_BLTOUCH) || ENABLED(ABL_NCSW)) || ENABLED(ABL_TOUCH_MI)
-  #if ((ENABLED(ABL_UBL)))
+#if ANY(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW, ABL_TOUCH_MI)
+  #if ENABLED(ABL_UBL)
     #define AUTO_BED_LEVELING_UBL
     #endif
-    #if ((ENABLED(ABL_BI)))
+    #if (ENABLED(ABL_BI)
       #define AUTO_BED_LEVELING_BILINEAR
     #endif
-#elif NONE(OrigLA)
+#elif DISABLED(OrigLA, MachineCR10Orig)
   #define MESH_BED_LEVELING
 #else
   #define ClipClearance 0

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1434,11 +1434,11 @@
     #endif
   #endif
 
-  #if ENABLED(EXTENSIBLE_UI) && NONE(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH)
+  #if ENABLED(EXTENSIBLE_UI) && NONE(ABL_EZABL, ABL_NCSW, ABL_BLTOUCH, ABL_TOUCH_MI)
     #define BABYSTEP_DISPLAY_TOTAL          // Display total babysteps since last G28
   #endif
 
-  #if ANY(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW)
+  #if ANY(ABL_EZABL, ABL_BLTOUCH, ABL_NCSW, ABL_TOUCH_MI)
     #define BABYSTEP_ZPROBE_OFFSET          // Combine M851 Z and Babystepping
   #endif
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)


### PR DESCRIPTION
### Requirements

Fix Touch-Mi sensor errors on Creality CR10 S Pro

### Description

Fixes for TOUCH_MI_PROBE. 

### Benefits

Fix compilation errors

### Related Issues

#84
