### PR TITLE
Typo fix on line 1969 in Configuration.h

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1966,7 +1966,7 @@
   #if ENABLED(ABL_UBL)
     #define AUTO_BED_LEVELING_UBL
     #endif
-    #if (ENABLED(ABL_BI)
+    #if ENABLED(ABL_BI)
       #define AUTO_BED_LEVELING_BILINEAR
     #endif
 #elif DISABLED(OrigLA, MachineCR10Orig)


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

There is a typo on line 1969 in configuration.h which has an extra opening bracket, this is causing a compile fail.

### Benefits

Fixes the typo.

### Related Issues


