### PR TITLE
Update Configuration.h

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -785,9 +785,9 @@
 #if ENABLED(PSU_CONTROL)
   #if ENABLED(PowerShutoffKit)
     #define PS_ON_PIN 12
-    #define PSU_ACTIVE_HIGH HIGH
+    #define PSU_ACTIVE_STATE HIGH
   #else
-    #define PSU_ACTIVE_HIGH FALSE      // Set 'LOW' for ATX, 'HIGH' for X-Box
+    #define PSU_ACTIVE_STATE LOW      // Set 'LOW' for ATX, 'HIGH' for X-Box
   #endif
 
   //#define PSU_DEFAULT_OFF         // Keep power off until enabled directly with M80


### PR DESCRIPTION
PSU_ACTIVE_HIGH should be PSU_ACTIVE_STATE

PSU_ACTIVE_STATE set from false to low.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
