### PR TITLE
Loop in M591_report is incorrect

### DIFF
--- a/Marlin/src/gcode/feature/runout/M591.cpp
+++ b/Marlin/src/gcode/feature/runout/M591.cpp
@@ -78,7 +78,7 @@ void GcodeSuite::M591() {
 
 void GcodeSuite::M591_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(STR_FILAMENT_RUNOUT_SENSOR));
-  LOOP_S_L_N(e, 1, NUM_RUNOUT_SENSORS)
+  LOOP_S_L_N(e, 0, NUM_RUNOUT_SENSORS)
     SERIAL_ECHOLNPGM(
       "  M591"
       #if MULTI_FILAMENT_SENSOR


### PR DESCRIPTION
M503 results before change:
```
echo:; Filament runout sensor:
Recv: echo:ok P31 B15

```
Final OK is incorrectly part of echo,  no  Filament runout sensor details

M503 results  after change:
```
echo:; Filament runout sensor:
echo:  M591 S1 D10.00 P2
ok P15 B3

```
This is correct.

### Requirements

Buld for a Ender 7 (or any others that have a filament runout sensor)

### Description

User was building for a Ender 7 and noticed this bug on discord as octoprint fails without receiving the OK on a new line
I found and sorted it for them.

### Benefits

Corrects M503 output, allows octoprint to work.

### Configurations

No changes to defaults 

